### PR TITLE
Build Docker image out of tree

### DIFF
--- a/somfyProtect2Mqtt/Dockerfile
+++ b/somfyProtect2Mqtt/Dockerfile
@@ -7,15 +7,11 @@ STOPSIGNAL SIGINT
 # SomfyProtect2MQTT version
 ARG VERSION=0.1.7
 
-# Download source and untar
-WORKDIR /usr/src
-ADD "https://github.com/Minims/SomfyProtect2MQTT/archive/refs/heads/dev.tar.gz" src.tar.gz
-RUN tar -xvf src.tar.gz
-RUN mv /usr/src/SomfyProtect2MQTT-dev /usr/src/SomfyProtect2MQTT
+ADD . /app
+WORKDIR /app
 
 # Install python requirements
-WORKDIR /usr/src/SomfyProtect2MQTT/somfyProtect2Mqtt
 RUN pip3 install -r requirements.txt
 
 # Run
-ENTRYPOINT ["./docker-entrypoint.sh"]
+ENTRYPOINT ["python3", "./main.py", "-c", "/config/config.yaml"]

--- a/somfyProtect2Mqtt/docker-compose.yml
+++ b/somfyProtect2Mqtt/docker-compose.yml
@@ -1,13 +1,7 @@
-version: "3.9"
+version: "3"
 services:
   somfyprotect2mqtt:
     build: .
-    environment:
-      TZ: Europe/Paris
     volumes:
-      - ./data:/data
-      - ./app:/app
-    command: tail -f /dev/null
+      - ./config:/config
 
-volumes:
-  mydata:


### PR DESCRIPTION
And fix docker-compose file.

With this patch you can directly create a docker image out of tree without getting a tar ball from github.

It also fixes the docker compose file to be able to start (and build) the image directly. The docker compose file expects the config file under config/config.yaml