### PR TITLE
adding opencv-python to fix missing cv2 module

### DIFF
--- a/somfyProtect2Mqtt/requirements_addon.txt
+++ b/somfyProtect2Mqtt/requirements_addon.txt
@@ -8,3 +8,4 @@ websocket-client==1.6.1
 pillow==10.0.0
 python-ffmpeg-video-streaming==0.1.15
 simple-http-server==0.21.1
+opencv-python==4.8.0.76


### PR DESCRIPTION
cv2 python module should be installed by installing opencv-python in python:3.11-slim