### PR TITLE
fix(webrtc): make the go2rtc HLS muxer able to produce a segment

### DIFF
--- a/somfyProtect2Mqtt/somfy_protect/webrtc_handler.py
+++ b/somfyProtect2Mqtt/somfy_protect/webrtc_handler.py
@@ -32,6 +32,11 @@ logging.getLogger("libav.h264").setLevel(logging.CRITICAL)
 logging.getLogger("libav.swscaler").setLevel(logging.CRITICAL)
 logging.getLogger("aiortc.codecs.h264").setLevel(logging.ERROR)
 
+# How long the HLS muxer waits for its first video frame. The tracks are handed over
+# before the ICE negotiation completes, and no frame can arrive until it does, so this
+# has to outlast that negotiation rather than the frame interval.
+HLS_TRACK_WAIT_SECONDS = 30
+
 
 class HLSHandler(BaseHTTPRequestHandler):
     """Serve HLS playlists and segments from memory."""
@@ -805,7 +810,7 @@ class WebRTCHandler:
             wait_start = time.time()
             while not muxer["video_ready"]:
                 elapsed = time.time() - wait_start
-                if elapsed > 5:
+                if elapsed > HLS_TRACK_WAIT_SECONDS:
                     LOGGER.error("[TRACKS] Timeout waiting for video track (>{:.1f}s), aborting muxer".format(elapsed))
                     return
                 await asyncio.sleep(0.1)
@@ -960,7 +965,7 @@ class WebRTCHandler:
                 height = video_frame.height
 
                 # Force a stable framerate to avoid mis-detected 120fps and segment glitches
-                fps = 30.0
+                fps = 30
                 gop = int(self.hls_segment_duration * fps)
                 LOGGER.debug(
                     "[VIDEO] Creating video stream {}x{} @ {:.2f}fps (gop={})".format(
@@ -1030,14 +1035,14 @@ class WebRTCHandler:
 
                     try:
                         audio_stream = container.add_stream("aac", rate=sample_rate)
-                        audio_stream.channels = num_channels
+                        audio_stream.layout = "mono" if num_channels == 1 else "stereo"
                         audio_stream.time_base = Fraction(1, sample_rate)
                         muxer["audio_stream"] = audio_stream
                     except (OSError, RuntimeError, ValueError):
                         # Fallback to MP3 if AAC fails
                         try:
                             audio_stream = container.add_stream("libmp3lame", rate=sample_rate)
-                            audio_stream.channels = num_channels
+                            audio_stream.layout = "mono" if num_channels == 1 else "stereo"
                             audio_stream.time_base = Fraction(1, sample_rate)
                             muxer["audio_stream"] = audio_stream
                             LOGGER.info("[AUDIO] Using MP3 codec (AAC unavailable)")


### PR DESCRIPTION
Relates to #257 — same symptom, root causes below.

The `go2rtc` backend never muxes a segment: the playlist is created, answers `200`, and stays empty forever, so any reader (go2rtc, VLC, ffmpeg) sees a stream that never starts. Three independent faults are in the way, each sufficient on its own.

### 1. The muxer's wait races the ICE negotiation, and loses

`_hls_muxer_task` waits 5 s for its first video frame. But the tracks are handed over *before* the ICE negotiation completes, and no frame can arrive until it does. On a residential connection that takes 6-7 s, so the muxer aborts one to two seconds before the video could start:

```
16:04:53,623  HLS muxer task started for device <id>
16:04:58,627  ICE connection state is checking
16:04:59,135  ICE connection state is completed
16:04:59,428  Connection state is connected
16:04:59,624  ICE connection successful!
```

and on a slower negotiation, the deadline lands first:

```
15:29:18,011  HLS muxer task started for device <id>
15:29:23,022  [TRACKS] Timeout waiting for video track (>5.0s), aborting muxer
15:29:24,536  ICE connection state is completed
15:29:24,700  Connection state is connected
```

The deadline now has a name, `HLS_TRACK_WAIT_SECONDS`, and outlasts the negotiation rather than the frame interval.

### 2. `add_stream(rate=...)` receives a float

`fps = 30.0` three lines above, where PyAV wants an int or a `Fraction`:

```
File "webrtc_handler.py", line 974, in _create_hls_segment
    video_stream = container.add_stream("libx264", rate=fps)
File "av/utils.py", line 58, in av.utils.to_avrational
    input.num = frac.numerator
AttributeError: 'float' object has no attribute 'numerator'
```

### 3. `audio_stream.channels` has been read-only since PyAV 14

The channel count is carried by the layout now. The surrounding `except` catches `OSError`, `RuntimeError` and `ValueError`, so this one propagates and takes the whole muxer task with it — including the MP3 fallback, which fails identically:

```
File "webrtc_handler.py", line 1033, in _create_hls_segment
AttributeError: attribute 'channels' of 'av.audio.codeccontext.AudioCodecContext' objects is not writable
```

Faults 2 and 3 are **unconditional**: with a current PyAV the first segment can never be created, for anyone. That is probably why the 5 s deadline in fault 1 went unnoticed — nothing ever got far enough to hit it.

### Verified

Raspberry Pi 5, Debian 12, Python 3.11, PyAV 17.1.0, aiortc 1.15.0, `streaming: go2rtc`, a Somfy Indoor Camera on the `webrtc` backend.

Before, at 5 s intervals through a whole session:

```
t= 5s code=200 taille=0
t=10s code=200 taille=0
t=15s code=200 taille=0
t=20s code=200 taille=0
t=25s code=200 taille=0
```

After, the same command:

```
t=12s segments=4
t=24s segments=8
t=36s segments=8
```

```
#EXTM3U
#EXT-X-VERSION:3
#EXT-X-INDEPENDENT-SEGMENTS
#EXT-X-TARGETDURATION:2
#EXT-X-MEDIA-SEQUENCE:19
#EXTINF:1.004,
segment19.ts
#EXTINF:1.014,
segment20.ts
```

ffmpeg reads that playlist and re-serves it without complaint. The `evostream` backend is untouched by these changes and still works.

### Note on fault 1

Raising the deadline is the small fix. The tidier one is to start the wait when the connection is established rather than when the tracks are handed over — happy to rework it that way if you prefer.