### PR TITLE
feat(webrtc): let the HLS server's address and port be configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,18 @@ HLS playlist on port `8090`.
 Use `stream_start` to start the camera stream. `stream_stop` is only supported
 by the Somfy `evostream` backend and is ignored when the camera uses `webrtc`.
 
+Where that server listens is configurable, and defaults to every interface:
+
+```yaml
+hls_host: 0.0.0.0
+hls_port: 8090
+```
+
+The playlist is unauthenticated, so an installation whose reader runs on the
+same host as SomfyProtect2MQTT can set `hls_host` to `127.0.0.1` and keep the
+camera off the local network. `hls_port` is there because `8090` is not this
+project's alone — `motion`, for one, hands it to its first camera.
+
 Configure go2rtc with the HLS URL:
 
 ```yaml

--- a/somfyProtect2Mqtt/config/config.yaml.example
+++ b/somfyProtect2Mqtt/config/config.yaml.example
@@ -31,6 +31,11 @@ delay_site: 10  # seconds
 delay_device: 60  # seconds
 manual_snapshot: false
 streaming: mqtt # mqtt or go2rtc (go2rtc only work for the HA Addon)
+# Where the go2rtc HLS server listens. Leave as is for the HA Addon, whose reader runs
+# in another container. Narrow it to 127.0.0.1 when the reader is on the same host, and
+# move the port if something else already holds 8090.
+hls_host: 0.0.0.0
+hls_port: 8090
 
 # Logging
 debug: false

--- a/somfyProtect2Mqtt/somfy_protect/webrtc_handler.py
+++ b/somfyProtect2Mqtt/somfy_protect/webrtc_handler.py
@@ -37,6 +37,12 @@ logging.getLogger("aiortc.codecs.h264").setLevel(logging.ERROR)
 # has to outlast that negotiation rather than the frame interval.
 HLS_TRACK_WAIT_SECONDS = 30
 
+# Where the HLS server listens. The defaults keep it reachable from another container,
+# as the Home Assistant add-on needs; an installation whose reader is on the same host
+# can narrow the address, and one whose port is already taken can move it.
+DEFAULT_HLS_HOST = "0.0.0.0"
+DEFAULT_HLS_PORT = 8090
+
 
 class HLSHandler(BaseHTTPRequestHandler):
     """Serve HLS playlists and segments from memory."""
@@ -149,7 +155,15 @@ class SilenceAudioTrack(AudioStreamTrack):
 class WebRTCHandler:
     """Handles WebRTC connections for Somfy Protect cameras"""
 
-    def __init__(self, mqtt_client, mqtt_config, send_websocket_callback, streaming_config=None):
+    def __init__(
+        self,
+        mqtt_client,
+        mqtt_config,
+        send_websocket_callback,
+        streaming_config=None,
+        hls_host=DEFAULT_HLS_HOST,
+        hls_port=DEFAULT_HLS_PORT,
+    ):
         """
         Initialize WebRTC handler
 
@@ -158,6 +172,8 @@ class WebRTCHandler:
             mqtt_config: MQTT configuration dict
             send_websocket_callback: Callback function to send WebSocket messages
             streaming_config: Streaming configuration ("mqtt", "go2rtc", etc.)
+            hls_host: Address the HLS server binds to
+            hls_port: Port the HLS server binds to
         """
         self.mqtt_client = mqtt_client
         self.mqtt_config = mqtt_config
@@ -171,7 +187,8 @@ class WebRTCHandler:
         self.hls_muxers = {}  # Store HLS muxers per device_id
         self.hls_segments = {}  # Store HLS segments and playlists per device_id
         self.hls_server = None
-        self.hls_port = 8090
+        self.hls_host = hls_host
+        self.hls_port = hls_port
         self.hls_segment_duration = 1  # seconds per segment (shorter to reduce boundary stalls)
 
     def store_turn_config(self, session_id, turn_data):
@@ -647,35 +664,40 @@ class WebRTCHandler:
         if self.hls_server:
             if device_id:
                 LOGGER.info(
-                    "HLS HTTP server already running on http://0.0.0.0:{}/{}/playlist.m3u8".format(
+                    "HLS HTTP server already running on http://{}:{}/{}/playlist.m3u8".format(
+                        self.hls_host,
                         self.hls_port,
                         device_id,
                     )
                 )
             else:
                 LOGGER.info(
-                    "HLS HTTP server already running on http://0.0.0.0:{}/<device_id>/playlist.m3u8".format(
-                        self.hls_port
+                    "HLS HTTP server already running on http://{}:{}/<device_id>/playlist.m3u8".format(
+                        self.hls_host,
+                        self.hls_port,
                     )
                 )
             return
         try:
-            server = ReusableHTTPServer(("0.0.0.0", self.hls_port), HLSHandler)
+            server = ReusableHTTPServer((self.hls_host, self.hls_port), HLSHandler)
         except OSError as e:
-            LOGGER.error("Unable to start HLS HTTP server on 0.0.0.0:{}: {}".format(self.hls_port, e))
+            LOGGER.error("Unable to start HLS HTTP server on {}:{}: {}".format(self.hls_host, self.hls_port, e))
             raise
         thread = threading.Thread(target=server.serve_forever, daemon=True)
         thread.start()
         self.hls_server = server
         if device_id:
             LOGGER.info(
-                "HLS HTTP server started on http://0.0.0.0:{}/{}/playlist.m3u8".format(
+                "HLS HTTP server started on http://{}:{}/{}/playlist.m3u8".format(
+                    self.hls_host,
                     self.hls_port,
                     device_id,
                 )
             )
         else:
-            LOGGER.info("HLS HTTP server started on http://0.0.0.0:{}/<device_id>/playlist.m3u8".format(self.hls_port))
+            LOGGER.info(
+                "HLS HTTP server started on http://{}:{}/<device_id>/playlist.m3u8".format(self.hls_host, self.hls_port)
+            )
 
     def _init_hls_muxer(self, device_id):
         """Initialize HLS muxer for a device"""
@@ -718,7 +740,8 @@ class WebRTCHandler:
 
         LOGGER.info(
             "Initialized HLS muxer for device {device_id} in {temp_dir}. "
-            "Playlist: http://0.0.0.0:{port}/{device_id}/playlist.m3u8".format(
+            "Playlist: http://{host}:{port}/{device_id}/playlist.m3u8".format(
+                host=self.hls_host,
                 device_id=device_id,
                 temp_dir=temp_dir,
                 port=self.hls_port,

--- a/somfyProtect2Mqtt/somfy_protect/websocket/__init__.py
+++ b/somfyProtect2Mqtt/somfy_protect/websocket/__init__.py
@@ -23,7 +23,7 @@ from mqtt import MQTTClient
 from oauthlib.oauth2 import MissingTokenError
 from somfy_protect.api import SomfyProtectApi
 from somfy_protect.sso import SomfyProtectSso, read_token_from_file
-from somfy_protect.webrtc_handler import WebRTCHandler
+from somfy_protect.webrtc_handler import DEFAULT_HLS_HOST, DEFAULT_HLS_PORT, WebRTCHandler
 from somfy_protect.websocket.handlers import alarm as alarm_handlers
 from somfy_protect.websocket.handlers import device as device_handlers
 from somfy_protect.websocket.handlers import video as video_handlers
@@ -58,6 +58,8 @@ class SomfyProtectWebsocket:
         self.mqtt_client = mqtt_client
         self.mqtt_config = config.get("mqtt")
         self.streaming_config = config.get("streaming")
+        self.hls_host = config.get("hls_host", DEFAULT_HLS_HOST)
+        self.hls_port = config.get("hls_port", DEFAULT_HLS_PORT)
         self.api = api
         self.sso = sso
         self.last_message_at = time.time()
@@ -72,6 +74,8 @@ class SomfyProtectWebsocket:
             mqtt_config=self.mqtt_config,
             send_websocket_callback=self.send_websocket_message,
             streaming_config=self.streaming_config,
+            hls_host=self.hls_host,
+            hls_port=self.hls_port,
         )
 
         # Create a dedicated event loop for async operations in a separate thread


### PR DESCRIPTION
Independent of #260, and safe to take in either order.

`webrtc_handler.py` writes the go2rtc HLS server's bind address and port into the source:

```python
self.hls_port = 8090
...
server = HTTPServer(("0.0.0.0", self.hls_port), HLSHandler)
```

This adds `hls_host` and `hls_port` to the configuration. **Both defaults are unchanged** — `0.0.0.0` and `8090` — so an installation that touches nothing behaves exactly as before, and the Home Assistant add-on keeps working, since its reader runs in another container and needs the wide default.

### Why the address

Where the reader is on the same host as the bridge, `0.0.0.0` publishes an unauthenticated camera stream to the entire local network, and nothing could narrow it. My reader is a small service on the same Raspberry Pi, so `hls_host: 127.0.0.1` is the correct setting — and it was not available.

This mirrors what motionEye already offers for the same reason (`listen 127.0.0.1` in `motioneye.conf`).

### Why the port

8090 is not the bridge's alone. `motion` gives it to its first camera by default, so an installation serving both a local camera and a Somfy one has a collision — and today only `motion` can be moved, because its port is configurable and this one was not. The conflict is quiet: the HLS server only binds when a video session starts, so it surfaces the first time someone streams a Somfy camera, long after the install.

### Verified

Raspberry Pi 5, Debian 12, Python 3.11, `streaming: go2rtc`, a Somfy Indoor Camera on the `webrtc` backend.

With `hls_host: 127.0.0.1` in `config.yaml`, during a live session:

```
$ ss -ltnp | grep 8090
LISTEN 0 5 127.0.0.1:8090 0.0.0.0:* users:(("python",pid=310685,fd=14))

$ curl -o /dev/null -w '%{http_code}\n' http://<lan-ip>:8090/<device_id>/playlist.m3u8
000

$ curl -o /dev/null -w '%{http_code}\n' http://127.0.0.1:8090/<device_id>/playlist.m3u8
200
```

Without the setting, the socket binds `0.0.0.0` and both requests answer 200, as before.